### PR TITLE
HeadLine, Margin, MoreButton 컴포넌트 완성

### DIFF
--- a/src/assets/theme.js
+++ b/src/assets/theme.js
@@ -1,6 +1,7 @@
 const colors = {
   white: '#ffffff',
   black: '#1B1313',
+  darkGray: '#A1A1A1',
   gray: '#d9d9d9',
   blue: '#0679C0',
   lightGray: '#f1f1f1',
@@ -20,12 +21,20 @@ const font = {
   `,
   large: `
     font-size: 22px;
+    font-weight: 600;
+    line-height: 26px;
   `,
   medium: `
     font-size: 16px;
+    font-weight: 600;
+  `,
+  mediumSmall: `
+    font-size: 14px;
+    font-weight: 600;
   `,
   small: `
     font-size: 12px;
+    font-weight: 600;
   `,
 };
 

--- a/src/components/HeadLine/HeadLine.jsx
+++ b/src/components/HeadLine/HeadLine.jsx
@@ -1,0 +1,43 @@
+/**
+ * firstLine, secondLine, emoji, subTitle, fontType
+ *
+ * fontType: 'extraLarge' | 'large' | 'medium' | 'small'
+ */
+
+import { styled } from 'styled-components';
+import Typo from '../Typo/Typo';
+import Margin from '../Margin/Margin';
+
+const HeadLineWrapper = styled.div`
+  margin-top: 32px;
+  width: 86%;
+`;
+
+const Emoji = styled.p`
+  font-size: 22px;
+  width: 82px;
+  height: 33px;
+`;
+
+const HeadTypo = styled(Typo)`
+  color: ${({ theme }) => theme.colors.black};
+`;
+
+const SubTitleTypo = styled(Typo)`
+  color: ${({ theme }) => theme.colors.darkGray};
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 32px;
+`;
+
+export default function HeadLine({ firstLine, secondLine, emoji, subTitle, fontType }) {
+  return (
+    <HeadLineWrapper>
+      {emoji && <Emoji>{emoji}</Emoji>}
+      {firstLine && <HeadTypo fontType={fontType}>{firstLine}</HeadTypo>}
+      {secondLine && <Margin height='4' />}
+      {secondLine && <HeadTypo fontType={fontType}>{secondLine}</HeadTypo>}
+      {subTitle && <SubTitleTypo>{subTitle}</SubTitleTypo>}
+    </HeadLineWrapper>
+  );
+}

--- a/src/components/Layout/Layout.jsx
+++ b/src/components/Layout/Layout.jsx
@@ -3,7 +3,7 @@ import { Outlet } from 'react-router-dom';
 import { styled } from 'styled-components';
 
 const BackGround = styled.div`
-  width: 500px;
+  width: 450px;
   background-color: ${({ theme }) => theme.colors.white};
 
   display: flex;

--- a/src/components/Margin/Margin.jsx
+++ b/src/components/Margin/Margin.jsx
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+
+const Margin = styled.div`
+  height: ${(props) => props.height}px;
+  width: ${(props) => props.width}px;
+`;
+
+export default Margin;

--- a/src/components/MoreButton/MoreButton.jsx
+++ b/src/components/MoreButton/MoreButton.jsx
@@ -1,0 +1,35 @@
+import Typo from '../Typo/Typo';
+import { styled } from 'styled-components';
+import arrow from '../../assets/Icons/Header/back.svg';
+
+const MoreButtonWrapper = styled.div`
+  cursor: pointer;
+  height: 12px;
+  ${({ theme }) => theme.font.small}
+  padding: 8px;
+  display: flex;
+  gap: 6px;
+  align-items: center;
+
+  > p {
+    padding-top: 2px;
+    color: ${({ theme }) => theme.colors.darkGray};
+  }
+`;
+
+export default function MoreButton({ onClick, children }) {
+  return (
+    <MoreButtonWrapper onClick={onClick}>
+      <Typo fontType='small'>{children}</Typo>
+      <img
+        src={arrow}
+        style={{
+          transform: 'rotate(180deg)',
+          height: '8px',
+          filter: 'invert(67%) sepia(0%) saturate(152%) hue-rotate(205deg) brightness(96%) contrast(91%)',
+        }}
+        alt='arrow'
+      />
+    </MoreButtonWrapper>
+  );
+}

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -1,6 +1,7 @@
 /* <div id='map' style={{ width: '500px', height: '400px' }}></div>; */
 
 import Button from '../components/Button/Button';
+import HeadLine from '../components/HeadLine/HeadLine';
 import Header from '../components/Header/Header';
 import Horizon from '../components/Hotrizon/Horizon';
 
@@ -13,6 +14,7 @@ const MainPage = () => {
       <Horizon />
       <div>hi</div>
       <Header underLine titleSize='large' title='요청사항 반영하기' left='back' right='home' />
+      <HeadLine fontType='mediumSmall' emoji='🔴🟡' firstLine='실시간으로 가장' secondLine='인기있는 디자인 랭킹' />
     </>
   );
 };

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -4,6 +4,7 @@ import Button from '../components/Button/Button';
 import HeadLine from '../components/HeadLine/HeadLine';
 import Header from '../components/Header/Header';
 import Horizon from '../components/Hotrizon/Horizon';
+import MoreButton from '../components/MoreButton/MoreButton';
 
 const MainPage = () => {
   return (
@@ -15,6 +16,7 @@ const MainPage = () => {
       <div>hi</div>
       <Header underLine titleSize='large' title='요청사항 반영하기' left='back' right='home' />
       <HeadLine fontType='mediumSmall' emoji='🔴🟡' firstLine='실시간으로 가장' secondLine='인기있는 디자인 랭킹' />
+      <MoreButton>전체보기</MoreButton>
     </>
   );
 };


### PR DESCRIPTION
# ✅ HeadLine 컴포넌트
: 아래 이미지같은 곳에 사용합니다.
<img width="832" alt="image" src="https://github.com/peterpet2023/peterpet-FE/assets/64801796/708958ed-8fb1-4e9d-834e-0646176197f9">

### 🔘 받는 props
<img width="730" alt="image" src="https://github.com/peterpet2023/peterpet-FE/assets/64801796/bcacd409-e554-4208-8b6d-b499a705b530">

### 🔘 사용 예시
<img width="895" alt="image" src="https://github.com/peterpet2023/peterpet-FE/assets/64801796/69bf4fbd-51e8-43d7-8fdb-0a6e04bce02d">

---

# ✅ Margin 컴포넌트
: 그냥 간격을 띄우고 싶을 때 사용합니다.

### 🔘 받는 props
- height: 수직 간격
- width: 수평 간격

### 🔘 사용 예시
<img width="415" alt="image" src="https://github.com/peterpet2023/peterpet-FE/assets/64801796/fe8a0132-eb50-4a62-b35e-03b17959651c">

(위 이미지처럼하면 `<HeadTypo>` 가 height 4px만큼 위아래로 멀어지게됨, gap이 생기는 것)

---

# ✅ MoreButton 컴포넌트
: 아래 이미지같은 곳에 사용합니다.
<img width="227" alt="image" src="https://github.com/peterpet2023/peterpet-FE/assets/64801796/e4772dbe-a000-4e95-b215-e0297e029293">

### 🔘 사용 예시
<img width="921" alt="image" src="https://github.com/peterpet2023/peterpet-FE/assets/64801796/a81fd5fb-39e2-48dd-a6d7-bdfd553f3456">

